### PR TITLE
Fixes PolytopeIntersector function names

### DIFF
--- a/sources/osgUtil/PolytopeIntersector.js
+++ b/sources/osgUtil/PolytopeIntersector.js
@@ -65,7 +65,7 @@ MACROUTILS.createPrototypeObject(
             ]);
         },
 
-        intersectBoundingSphere: function(bbox) {
+        intersectBoundingBox: function(bbox) {
             return this._iPolytope.containsBoundingBox(bbox);
         },
 


### PR DESCRIPTION
The intersector function name was misspelled, causing two functions to have the same name.