### PR TITLE
Supports multiple gl contexts

### DIFF
--- a/sources/osg/TimerGPU.js
+++ b/sources/osg/TimerGPU.js
@@ -19,14 +19,15 @@ var TimerGPU = function(gl) {
 
 TimerGPU.FRAME_COUNT = 0;
 
+TimerGPU._instance = new Map();
+
 TimerGPU.instance = function(gl, force) {
-    if (!TimerGPU._instance) {
-        TimerGPU._instance = new TimerGPU(gl);
-    } else if (gl && (TimerGPU._instance.getContext() !== gl || force)) {
-        TimerGPU._instance.setContext(gl);
-        TimerGPU._instance.reset(gl);
+    if (!TimerGPU._instance.has(gl)) {
+        TimerGPU._instance.set(gl, new TimerGPU(gl));
+    } else if (gl && force) {
+        TimerGPU._instance.get(gl).reset(gl);
     }
-    return TimerGPU._instance;
+    return TimerGPU._instance.get(gl);
 };
 
 TimerGPU.prototype = {


### PR DESCRIPTION
Using multiple viewers causes the TimerGPU to reset all viewers every frame.
This PR allows the use of multiple viewers with its different GL contexts.